### PR TITLE
Bump opal dependency to 0.9.2

### DIFF
--- a/lib/opal/pixi/version.rb
+++ b/lib/opal/pixi/version.rb
@@ -1,5 +1,5 @@
 module Opal
   module PIXI
-    VERSION = '0.3.4'
+    VERSION = '0.3.5'
   end
 end

--- a/opal-pixi.gemspec
+++ b/opal-pixi.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.test_files     = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths  = ['lib']
 
-  s.add_runtime_dependency 'opal', '>= 0.8.0', '< 0.9.0'
-  s.add_development_dependency 'opal-rspec', '~> 0.4.0'
+  s.add_runtime_dependency 'opal', '~> 0.9.2'
+  s.add_development_dependency 'opal-rspec'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Just updating `opal` dependency.

This fixes `Math` module issues old `opal` had.
